### PR TITLE
Increase timeout to run tests after server start

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,7 +59,7 @@ app.listen(process.env.PORT || 3000, function () {
           console.log('Tests are not valid:');
           console.log(error);
       }
-    }, 1500);
+    }, 2500);
   }
 });
 


### PR DESCRIPTION
MongoDB atlas connection takes around 2 secs to get connected, causing tests at the start to fail