### PR TITLE
fix: update headers test code

### DIFF
--- a/routes/fcctesting.js
+++ b/routes/fcctesting.js
@@ -73,12 +73,7 @@ module.exports = function (app) {
     });
   });
   app.get('/_api/app-info', function(req, res) {
-    var hs = Object.keys(res._headers)
-      .filter(h => !h.match(/^access-control-\w+/));
-    var hObj = {};
-    hs.forEach(h => {hObj[h] = res._headers[h]});
-    delete res._headers['strict-transport-security'];
-    res.json({headers: hObj});
+    res.json({ headers: res.getHeaders()});
   });
   
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/44174

<!-- Feel free to add any additional description of changes below this line -->
This updates the headers code to not use deprecated methods, and removes the (apparently unnecessary) code that strips the access control headers.

Testing on Glitch:

```js
app.get('/_api/app-info', function(req, res) {
  res.json({ headers: res.getHeaders()});
});
```

Returns `{"headers":{"x-powered-by":"Express","access-control-allow-origin":"*","x-frame-options":"DENY","x-dns-prefetch-control":"off","referrer-policy":"same-origin"}}`

```js
  app.get('/_api/app-info', function(req, res) {
    var hs = Object.keys(res._headers)
      .filter(h => !h.match(/^access-control-\w+/));
    var hObj = {};
    hs.forEach(h => {hObj[h] = res._headers[h]});
    delete res._headers['strict-transport-security'];
    res.json({headers: hObj});
  });
```

Returns `{"headers":{"x-powered-by":"Express","x-frame-options":"DENY","x-dns-prefetch-control":"off","referrer-policy":"same-origin"}}`